### PR TITLE
fix handling of some malformed css

### DIFF
--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -147,6 +147,42 @@ describe('Parser', () => {
             nodeFactory.discarded(';')
           ]));
     });
+
+    it('can parse empty selectors', () => {
+      expect(parser.parse('{ empty-a } { empty-b } empty-c { empty-d }'))
+          .to.containSubset(nodeFactory.stylesheet([
+            nodeFactory.ruleset(
+              '', nodeFactory.rulelist([
+                nodeFactory.declaration('empty-a', undefined)])),
+            nodeFactory.ruleset(
+              '', nodeFactory.rulelist([
+                nodeFactory.declaration('empty-b', undefined)])),
+            nodeFactory.ruleset(
+              'empty-c', nodeFactory.rulelist([
+                nodeFactory.declaration('empty-d', undefined)])),
+          ]));
+    });
+
+    it('can parse unclosed blocks', () => {
+      expect(parser.parse('uncl-a { uncl-b: uncl-c uncl-d'))
+          .to.containSubset(nodeFactory.stylesheet([
+            nodeFactory.ruleset(
+              'uncl-a', nodeFactory.rulelist([
+                nodeFactory.declaration(
+                  'uncl-b', nodeFactory.expression('uncl-c uncl-d'))
+              ]))
+          ]));
+    });
+
+    it('can parse unclosed blocks without a colon', () => {
+      expect(parser.parse('uncol-a { uncol-b'))
+          .to.containSubset(nodeFactory.stylesheet([
+            nodeFactory.ruleset(
+              'uncol-a', nodeFactory.rulelist([
+                nodeFactory.declaration('uncol-b', undefined)
+            ]))
+          ]));
+    });
   });
 
   describe('when extracting ranges', () => {

--- a/src/test/stringifier-test.ts
+++ b/src/test/stringifier-test.ts
@@ -107,6 +107,14 @@ describe('Stringifier', () => {
       expect(cssText).to.be.eql(':root{--qux:vim;--foo:{bar:baz;};}');
     });
 
+    it('can stringify empty selectors', () => {
+      const cssText =
+          stringifier.stringify(parser.parse(
+              '{ empty-a } { empty-b } empty-c { empty-d }'));
+      expect(cssText).to.be
+          .eql('{empty-a;}{empty-b;}empty-c{empty-d;}');
+    });
+
     describe('with discarded nodes', () => {
       it('stringifies to a corrected stylesheet', () => {
         const cssText =


### PR DESCRIPTION
This fixes two incompatibilities between shady-css-parser
and browsers.

1. If the css is missing a closing brace like
       div { color:red
   then Shady drops the last rule, but browsers keep it.

2. If a css ruleset has an empty selector like
       `/*empty*/` { color: red }
       div { color: blue }
   then Shady discards the { } and produces this:
       color:red;div { color: blue; }
   which has an entirely different meaning.

   Browsers parse the empty-selector block, but then ignore it
   as invalid.

   For this case, we could either make Shady keep the block
   or drop the block. I decided to keep the block, because
   Shady generally passes through many other not-quite-valid
   css text that browsers would ignore.