### PR TITLE
Fix parsing for minified css with extra semicolons

### DIFF
--- a/src/shady-css/parser.ts
+++ b/src/shady-css/parser.ts
@@ -131,7 +131,7 @@ class Parser {
     }
 
     while (tokenizer.currentToken &&
-           tokenizer.currentToken.is(TokenType.boundary)) {
+           tokenizer.currentToken.is(TokenType.semicolon)) {
       end = tokenizer.advance();
     }
 

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -68,6 +68,8 @@ div {
 
 export const minifiedRuleset = '.foo{bar:baz}div .qux{vim:fet;}';
 
+export const minifiedRulesetWithExtraSemicolons = '.foo{bar:baz;;}div .qux{vim:fet;}';
+
 export const psuedoRuleset = '.foo:bar:not(#rif){baz:qux}';
 
 export const dataUriRuleset = '.foo{bar:url(qux;gib)}';

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -183,6 +183,18 @@ describe('Parser', () => {
             ]))
           ]));
     });
+
+    it('can parse minified rulelists with extra semicolons', () => {
+      expect(parser.parse(fixtures.minifiedRulesetWithExtraSemicolons))
+          .to.containSubset(nodeFactory.stylesheet([
+            nodeFactory.ruleset(
+                '.foo', nodeFactory.rulelist([nodeFactory.declaration(
+                            'bar', nodeFactory.expression('baz'))])),
+            nodeFactory.ruleset(
+                'div .qux', nodeFactory.rulelist([nodeFactory.declaration(
+                                'vim', nodeFactory.expression('fet'))]))
+          ]));
+    });
   });
 
   describe('when extracting ranges', () => {


### PR DESCRIPTION
This fixes the scenario where extra semicolons are immediately
followed (without whitespace) by a boundary token such as '}'.

For the ruleset: .foo{bar:baz;;}div .qux{vim:fet;}

Shady treats the first `}' as an extra token and adds div .qux rule
under the .foo selector.